### PR TITLE
add api docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # HelmIt API
 
 An API which gives insight to running containers.
+
+### GET `/shipment/status/:barge/:shipment/:environment`
+
+> Returns an object that has the status of all containers running in the Shipment.
+
+
+### GET `/shipment/events/:barge/:shipment/:environment`
+
+> Returns an object with the events from all containers running in the Shipment.
+
+
+## GET `/harbor/:barge/:shipment/:environment`
+
+> Returns an object with an array of containers that have data to be displayed in the Harbor UI
+> including the container logs.


### PR DESCRIPTION
Added some basic documentation for HelmIt API.

The reason for the bump from `0.1.0` to `0.4.0` is that HelmIt is currently running at `0.3.1`—this will allow for a more seamless transition from the old codebase to this.
