### PR TITLE
fix(containers): make sure we remove the first 8 chars of the lines

### DIFF
--- a/lib/containers.js
+++ b/lib/containers.js
@@ -19,9 +19,12 @@ const fetch = context => {
                 debug('fetch end', context.id);
                 // get the body by filtering out the header lines, join together then spliting on new
                 // lines so that we don't get awkward breaks
-                // New kube/docker doesn't like the filteriner of header characters; commenting out
-                //context.body = body.filter(line => !/^[\x00\x01\x02].*/.test(line)).join('').split('\n');
-                context.body = body;
+                // The first 8 lines are header information of each line. Remove these.
+                // https://github.com/docker/docker/issues/14201
+                context.body = body.join('').split('\n');
+                context.body = body.map((line) => {
+                  return line.substring(8);
+                });
                 resolve(context);
             });
         });


### PR DESCRIPTION
This is breaking harbor-compose, as it cannot parse the logs and get the correct timestamp. This fixes the issue and has been done across the community in different places. 

https://github.com/hyperhq/hypernetes/pull/128
