### PR TITLE
fix(license): update copyright owner name

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright 2016 Turner
+Copyright 2016 Turner Broadcasting Systems, Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.


### PR DESCRIPTION
Continuing to use the [license boilerplate](http://www.apache.org/licenses/LICENSE-2.0#apply) that the Apache Foundation recommends.
