### PR TITLE
fix(containers): add timeout to requests

### DIFF
--- a/lib/containers.js
+++ b/lib/containers.js
@@ -2,8 +2,9 @@
 
 const debug = require('debug')('helmit:containers'),
     Promise = require('bluebird'),
-    http = require('http');
-
+    http = require('http'),
+    SERVER_TIMEOUT = parseInt(process.env.SERVER_TIMEOUT, 10) || 10;
+    
 const fetch = context => {
     return new Promise((resolve, reject) => {
         debug('fetch', context.id);
@@ -28,6 +29,13 @@ const fetch = context => {
                 resolve(context);
             });
         });
+        request.on('socket', function (socket) {
+            // if it takes longer than 10 seconds to get the logs, then fail
+            socket.setTimeout(1000 * SERVER_TIMEOUT);  
+            socket.on('timeout', function() {
+                request.abort();
+            });
+        });
         request.on('error', err => reject(err));
     });
 };
@@ -42,7 +50,7 @@ module.exports = {
             contexts = [];
 
         logUrl = logUrl.replace('$PORT', containerPort).replace('$SIZE', logSize);
-
+        
         if (req.helmit.nodes.length) {
             debug('nodes', req.helmit.nodes);
             req.helmit.nodes.forEach(node => {
@@ -52,7 +60,7 @@ module.exports = {
                         .replace('$ID', container.id);
 
                     container.log_stream = logStream.replace('$LOG_URL', url);
-                    container.logs = [];
+                    container.logs;
 
                     contexts.push({id: container.id, url: url});
                 });
@@ -60,10 +68,10 @@ module.exports = {
 
             Promise.map(contexts, context => {
                     debug('log context', context);
-                    return fetch(context);
+                    return fetch(context).then(payload => ({ success: true, id: payload.id, body: payload.body }), err => ({ success: false, err }));
                 })
                 .then(contexts => {
-                    // Context is a array of objects with two fields
+                    // Contexts is a array of objects with two fields
                     // Field 1 is id: which maps to the container id
                     // Field 2 is body: which are the logs
                     // Need to go through each context and put it into place
@@ -71,13 +79,29 @@ module.exports = {
                     // Then that object is placed into the result
                     debug('cycling contexts (length %s)', contexts.length);
                     contexts.forEach(context => {
-                        req.helmit.nodes.forEach(node => {
-                            node.containers.forEach(container => {
-                                if (context.id === container.id) {
-                                    container.logs = context.body;
-                                }
+                        if (context.success) {
+                            req.helmit.nodes.forEach(node => {
+                                node.containers.forEach(container => {
+                                    if (context.id === container.id) {
+                                        container.logs = context.body;
+                                    }
+                                });
                             });
-                        });
+                        }
+                    });
+                    
+                    // if there were any unsuccessful attempts to get logs, then add the reason why
+                    // that attempt failed
+                    contexts.forEach(context => {
+                        if (!context.success) {
+                            req.helmit.nodes.forEach(node => {
+                                node.containers.forEach(container => {
+                                    if (!container.logs) {
+                                        container.logs = `Failed to Get Container Logs Because: ${context.err}`;
+                                    }
+                                });
+                            });
+                        }
                     });
 
                     result.replicas = req.helmit.nodes;


### PR DESCRIPTION
- adding timeout to request for docker logs. 
  - default timeout is 10 seconds. This can be modified to via SERVER_TIMEOUT.
- if there is an error with on logs fetch, we will still return other successful requests. The one that failed will get it's logs overwritten with the error that occurred, as the reason why we failed to get logs. 
