### PR TITLE
use name, not generateName

### DIFF
--- a/lib/k8sClient.js
+++ b/lib/k8sClient.js
@@ -140,7 +140,7 @@ module.exports = {
                     let obj = {};
 
                     obj.host = item.status.hostIP;
-                    obj.name = item.metadata.generateName;
+                    obj.name = item.metadata.name;
                     obj.phase = item.status.phase.toLowerCase();
                     obj.provider = process.env.LOCATION || 'ec2';
                     obj.containers = item.status.containerStatuses.map(status => {


### PR DESCRIPTION
Host names are truncated due to using the value `generateName` instead of `name`.