### PR TITLE
Add first and last seen

### DIFF
--- a/lib/k8sClient.js
+++ b/lib/k8sClient.js
@@ -67,18 +67,16 @@ function eventsTransform(data) {
 
     result.namespace = data.metadata.selfLink.split('/')[4];
     result.version = data.metadata.resourceVersion;
-    result.events = [];
-
-    data.items.forEach(evt => {
-        var temp = {
-                type: evt.type,
-                count: evt.count,
-                reason: evt.reason,
-                message: evt.message,
-                source: evt.source
-            };
-
-        result.events.push(temp);
+    result.events = data.items.map(evt => {
+        return {
+            type: evt.type,
+            count: evt.count,
+            reason: evt.reason,
+            message: evt.message,
+            source: evt.source,
+            firstTimestamp: evt.firstTimestamp,
+            lastTimestamp: evt.lastTimestamp
+        };
     });
 
     return result;

--- a/test/index.js
+++ b/test/index.js
@@ -264,7 +264,7 @@ describe('Shipment Events', function () {
                 }
 
                 let obj = res.body,
-                    required = ['type', 'count', 'reason', 'message', 'source'];
+                    required = ['type', 'count', 'reason', 'message', 'source', 'firstTimestamp', 'lastTimestamp'];
 
                 expect(obj.namespace).to.equal('hello-world-app-dev');
                 expect(obj.events).to.have.length.of.at.least(1);


### PR DESCRIPTION
Adding a couple of timestamps to make it clearer when a particular issue was first reported and when it was last seen.

Also, redid the code. There is no need to `Array.forEach` and `Array.push` onto an empty array when you can just use `Array.map`.