### PR TITLE
Pod IP

### DIFF
--- a/lib/k8sClient.js
+++ b/lib/k8sClient.js
@@ -41,6 +41,7 @@ function statusTransform(data) {
                 status.id = 'pending';
             }
             status.host  = item.status.hostIP;
+            status.podIp = item.status.podIP || 'unset';
             status.replica = item.metadata.name;
             status.image = container.image;
             status.ready = container.ready;

--- a/lib/k8sClient.js
+++ b/lib/k8sClient.js
@@ -41,7 +41,7 @@ function statusTransform(data) {
                 status.id = 'pending';
             }
             status.host  = item.status.hostIP;
-            status.podIp = item.status.podIP || 'unset';
+            status.podIp = item.status.podIP || null;
             status.replica = item.metadata.name;
             status.image = container.image;
             status.ready = container.ready;

--- a/test/index.js
+++ b/test/index.js
@@ -178,7 +178,7 @@ describe('Shipment Status', function () {
                 let obj = res.body,
                     required = ['averageRestarts', 'status', 'namespace', 'version'],
                     reqStatus = ['conditions', 'containers', 'phase'],
-                    reqContainers = ['host', 'id', 'image', 'ready', 'replica', 'restarts', 'state', 'status'];
+                    reqContainers = ['host', 'id', 'image', 'ready', 'replica', 'restarts', 'podIp', 'state', 'status'];
 
                 required.forEach(prop => expect(obj).to.have.property(prop));
                 reqStatus.forEach(prop => expect(obj.status).to.have.property(prop));


### PR DESCRIPTION
Not much to say other than pod IP is now on the Status endpoint.

If the pod hasn't yet gotten a IP (which does happen from time to time), the IP will be `'unset'`. I was contemplating using the value `'0.0.0.0'` but felt like 1) that's _so_ IPv4 and 2) it's not quite as clear as `'unset'`.